### PR TITLE
[fix]: update timestamp of received message to local time

### DIFF
--- a/lanshare/core/udp_discovery.py
+++ b/lanshare/core/udp_discovery.py
@@ -110,6 +110,7 @@ class UDPPeerDiscovery(PeerDiscovery):
         try:
             msg = Message.from_dict(packet['data'])
             if msg.recipient == self.username:
+                msg.timestamp = datetime.now() # update to received time
                 self.messages.append(msg)
                 self.debug_print(f"Received message from {msg.sender}: {msg.title}")
         except Exception as e:


### PR DESCRIPTION
fix #10 
In the message channel, the timestamp of message from the peer will be the local time it received the message. 